### PR TITLE
Another UTF-8 encoding related fix

### DIFF
--- a/CouchDB.cabal
+++ b/CouchDB.cabal
@@ -1,5 +1,5 @@
 Name:           CouchDB
-Version:        0.11.0
+Version:        0.12.0
 Cabal-Version:	>= 1.2.4
 Copyright:      Copyright (c) 2008-2009 Arjun Guha and Brendan Hickey
 License:        BSD3

--- a/src/Database/CouchDB.hs
+++ b/src/Database/CouchDB.hs
@@ -67,15 +67,16 @@ instance JSON DB where
 
   showJSON (DB s) = showJSON s
 
--- isDBChar ch = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') 
---     || (ch >= '0' && ch <= '9')
-
 isDBFirstChar ch = (ch >= 'a' && ch <= 'z') 
 
 isDBOtherChar ch = (ch >= 'a' && ch <= 'z') 
     || (ch >= '0' && ch <= '9') || ch `elem` "_$()+-/"
 
-isFirstDocChar = isDBFirstChar
+-- Pretty much anything is accepted in document IDs, but avoid the
+-- initial '_' as it is reserved. It is likely possible to accept
+-- more, but this includes at least the auto-generated IDs.
+isFirstDocChar ch = (ch >= 'A' && ch <='Z') || (ch >= 'a' && ch <= 'z') 
+  || (ch >= '0' && ch <= '9') || ch `elem` "-@."
 
 isDocChar ch = (ch >= 'A' && ch <='Z') || (ch >= 'a' && ch <= 'z') 
   || (ch >= '0' && ch <= '9') || ch `elem` "-@._"

--- a/src/Database/CouchDB.hs
+++ b/src/Database/CouchDB.hs
@@ -67,18 +67,23 @@ instance JSON DB where
 
   showJSON (DB s) = showJSON s
 
+-- isDBChar ch = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') 
+--     || (ch >= '0' && ch <= '9')
 
-isDBChar ch = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') 
-    || (ch >= '0' && ch <= '9')
+isDBFirstChar ch = (ch >= 'a' && ch <= 'z') 
 
-isFirstDocChar = isDBChar
+isDBOtherChar ch = (ch >= 'a' && ch <= 'z') 
+    || (ch >= '0' && ch <= '9') || ch `elem` "_$()+-/"
+
+isFirstDocChar = isDBFirstChar
 
 isDocChar ch = (ch >= 'A' && ch <='Z') || (ch >= 'a' && ch <= 'z') 
   || (ch >= '0' && ch <= '9') || ch `elem` "-@._"
 
 isDBString :: String -> Bool
 isDBString [] =  False
-isDBString s = and (map isDBChar s)
+isDBString (first:[]) = isDBFirstChar first
+isDBString (first:rest) = isDBFirstChar first && and (map isDBOtherChar rest)
 
 -- |Returns a safe database name.  Signals an error if the name is
 -- invalid.

--- a/src/Database/CouchDB/Unsafe.hs
+++ b/src/Database/CouchDB/Unsafe.hs
@@ -286,7 +286,7 @@ getAllDocs :: JSON a
           -- |Returns a list of rows.  Each row is a key, value pair.
           -> CouchMonad [(JSString, a)]
 getAllDocs db args = do
-  let args' = map (\(k,v) -> (k,encode v)) args
+  let args' = map (\(k,v) -> (k,enc v)) args
   let url' = concat [db, "/_all_docs"]
   r <- request url' args' GET [] ""
   case rspCode r of
@@ -322,7 +322,7 @@ queryView :: (JSON a)
           -- |Returns a list of rows.  Each row is a key, value pair.
           -> CouchMonad [(JSString, a)]
 queryView db viewSet view args = do
-  let args' = map (\(k,v) -> (k,encode v)) args
+  let args' = map (\(k,v) -> (k,enc v)) args
   let url' = concat [db, "/_design/", viewSet, "/_view/", view]
   r <- request url' args' GET [] ""
   case rspCode r of
@@ -340,7 +340,7 @@ queryViewKeys :: String  -- ^database
             -> [(String, JSValue)] -- ^query parameters
             -> CouchMonad [String]
 queryViewKeys db viewSet view args = do
-  let args' = map (\(k,v) -> (k,encode v)) args
+  let args' = map (\(k,v) -> (k,enc v)) args
   let url' = concat [db, "/_design/", viewSet, "/_view/", view]
   r <- request url' args' GET [] ""
   case rspCode r of


### PR DESCRIPTION
Hey,

there was another issue with UTF-8 encoding: Values of query params in URLs were not properly UTF-8 encoded, hence resulting CouchDB responding with "Bad request" when putting special characters in there (e.g. when querying a view with a key value). This should be fixed by now.

Thanks,
Timo
