### PR TITLE
Added support for the couch _all_dbs method

### DIFF
--- a/CouchDB.cabal
+++ b/CouchDB.cabal
@@ -1,5 +1,5 @@
 Name:           CouchDB
-Version:        0.11.0
+Version:        0.11.1
 Cabal-Version:	>= 1.2.4
 Copyright:      Copyright (c) 2008-2009 Arjun Guha and Brendan Hickey
 License:        BSD3

--- a/src/Database/CouchDB.hs
+++ b/src/Database/CouchDB.hs
@@ -15,6 +15,7 @@ module Database.CouchDB
   , isDBString
   , createDB
   , dropDB
+  , getAllDBs
   -- * Documents
   , Doc
   , Rev
@@ -151,6 +152,10 @@ createDB = U.createDB
 
 dropDB :: String -> CouchMonad Bool -- ^False if the database does not exist
 dropDB = U.dropDB
+
+getAllDBs :: CouchMonad [DB]
+getAllDBs = U.getAllDBs
+  >>= \dbs -> return [db $ fromJSString s | s <- dbs]
 
 newNamedDoc :: (JSON a)
             => DB -- ^database name

--- a/src/Database/CouchDB/Unsafe.hs
+++ b/src/Database/CouchDB/Unsafe.hs
@@ -5,6 +5,7 @@ module Database.CouchDB.Unsafe
   -- * Databases
     createDB
   , dropDB
+  , getAllDBs
   -- * Documents
   , newNamedDoc
   , newDoc
@@ -60,6 +61,16 @@ dropDB name = do
     (2,0,0) -> return True
     (4,0,4) -> return False
     otherwise -> error (rspReason resp)
+
+getAllDBs :: CouchMonad [JSString]
+getAllDBs = do
+  response <- request' "_all_dbs" GET
+  case rspCode response of
+    (2,0,0) ->
+      case dec (rspBody response) of
+        Ok (JSArray dbs) -> return [db | JSString db <- dbs]
+        otherwise        -> error "Unexpected couch response"
+    otherwise -> error (show response)
 
 newNamedDoc :: (JSON a)
             => String -- ^database name


### PR DESCRIPTION
Couch allows you to get a list of all databases, much like you can get all documents in a database, so I added support for that.  Also, whether you pull this or not, could you make another hackage release?  The current one doesn't allow non-alphanumeric database names (such as databases with dots or hyphens in their names).  Thanks!
