### PR TITLE
Added support for password authentication.

### DIFF
--- a/src/Database/CouchDB.hs
+++ b/src/Database/CouchDB.hs
@@ -4,10 +4,12 @@ module Database.CouchDB
     CouchMonad
   , runCouchDB
   , runCouchDB'
+  , runCouchDBURI
    -- * Explicit Connections
   , CouchConn()
   , runCouchDBWith  
   , createCouchConn
+  , createCouchConnFromURI
   , closeCouchConn  
   -- * Databases
   , DB


### PR DESCRIPTION
Hi!

I have added support for HTTP authentication. The code is not throughoutly tested but works in my environment. Feel free to rewrite if my implementation is not fulfilling your standards. :-)

With this patch it is possible to connect by giving an URI with embedded login credentials. For example:

``` haskell
let Just u = parseURI "http://foo:bar@database.example.com:5984"
runCouchDBURI u (getDoc (db "measurements") (doc "ef6f297beb0b2dfaa3291688e700068e"))
```

NB. I'm not completely satisfied with _network_ and _HTTP_ library. I needed to do somewhat ugly hacks to extract credentials from an URI. But it works.™
