### PR TITLE
Proper UTF-8 encoding

### DIFF
--- a/CouchDB.cabal
+++ b/CouchDB.cabal
@@ -20,7 +20,7 @@ Test-Suite test-couchdb
   Type: exitcode-stdio-1.0
   Main-Is: Tests.hs
   Build-Depends:
-    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7, HUnit
+    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7, HUnit, bytestring
   Extensions:
     FlexibleInstances
   ghc-options:
@@ -29,7 +29,7 @@ Test-Suite test-couchdb
 Library
   Hs-Source-Dirs: src
   Build-Depends:
-    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7
+    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7, bytestring
   ghc-options:
     -fwarn-incomplete-patterns
   Extensions:     


### PR DESCRIPTION
Currently, CouchDB uses the String API of HTTP, which internally mangles unicode chars by using the .Char8 interface.

There seems to have been a workaround attempted for this by passing a pre-encoded “String” instead; but apparently CouchDB rejects this - it fails with a 400 Bad Request whenever I try passing it JSON data containing unicode.

I've fixed it by switching to the ByteString API instead and setting the appropriate Content-Encoding headers.
