### PR TITLE
Fixes to enable compilations with newer packages

### DIFF
--- a/CouchDB.cabal
+++ b/CouchDB.cabal
@@ -20,7 +20,7 @@ Test-Suite test-couchdb
   Type: exitcode-stdio-1.0
   Main-Is: Tests.hs
   Build-Depends:
-    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7, HUnit, bytestring
+    base >= 4 && < 5, mtl, containers, network-uri, HTTP>=4000.0.4, json>=0.4.3, utf8-string, HUnit, bytestring
   Extensions:
     FlexibleInstances
   ghc-options:
@@ -29,7 +29,7 @@ Test-Suite test-couchdb
 Library
   Hs-Source-Dirs: src
   Build-Depends:
-    base >= 4 && < 5, mtl, containers, network, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 0.3.7, bytestring
+    base >= 4 && < 5, mtl, containers, network-uri, HTTP>=4000.0.4, json>=0.4.3, utf8-string, bytestring
   ghc-options:
     -fwarn-incomplete-patterns
   Extensions:     

--- a/src/Tests.hs
+++ b/src/Tests.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
 import Control.Monad.Trans (liftIO)
-import Control.Exception (finally)
+import Control.Exception (SomeException, catch, finally)
 import Test.HUnit
 import Database.CouchDB
 import Database.CouchDB.JSON
@@ -44,7 +45,7 @@ testWithDB testDescription testCase =
           result <- testCase (db "haskellcouchdbtest")
           liftIO $ assertBool testDescription result
     let teardown = runCouchDB' (dropDB "haskellcouchdbtest") 
-    let failure _ = assertFailure (testDescription ++ "; exception signalled")
+    let failure (_::SomeException) = assertFailure (testDescription ++ "; exception signalled")
     action `catch` failure `finally` teardown
  
 main = do


### PR DESCRIPTION
- removed utf string version limitation
- changed dependency on network to network-uri since that package was forked
- fixed src/Test.hs

These changes allow this package to compile with ghc-7.8.3, cabal 1.20 and the newer versions of packages on hackage.

I haven't yet tested the new compile thoroughly, I will let you know if I encounter any bugs.
